### PR TITLE
Fix feature type "any" queries

### DIFF
--- a/src/components/definitionExpressionManager.test.ts
+++ b/src/components/definitionExpressionManager.test.ts
@@ -249,9 +249,9 @@ describe('createDefinitionExpression', () => {
     let result = generateDefinitionExpression(state);
 
     expect(result).toEqual({
-      centroids: `Project_ID in(select Project_ID from POINT where TypeDescription='Fish passage structure' intersect select Project_ID from LINE where TypeDescription='Dam')`,
-      point: `TypeDescription in('Fish passage structure') and Project_ID in(select Project_ID from POINT where TypeDescription='Fish passage structure' intersect select Project_ID from LINE where TypeDescription='Dam')`,
-      line: `TypeDescription in('Dam') and Project_ID in(select Project_ID from POINT where TypeDescription='Fish passage structure' intersect select Project_ID from LINE where TypeDescription='Dam')`,
+      centroids: `Project_ID in(select Project_ID from POINT where TypeDescription='Fish passage structure') and Project_ID in(select Project_ID from LINE where TypeDescription='Dam')`,
+      point: `TypeDescription in('Fish passage structure') and Project_ID in(select Project_ID from POINT where TypeDescription='Fish passage structure') and Project_ID in(select Project_ID from LINE where TypeDescription='Dam')`,
+      line: `TypeDescription in('Dam') and Project_ID in(select Project_ID from POINT where TypeDescription='Fish passage structure') and Project_ID in(select Project_ID from LINE where TypeDescription='Dam')`,
       poly: `1=0`,
     });
 

--- a/src/components/definitionExpressionManager.ts
+++ b/src/components/definitionExpressionManager.ts
@@ -90,7 +90,9 @@ const centroidStatusExpression = (predicateCsv: string) => `Status in(${predicat
 const unionProjectIdSubqueries = (g: GeometryKey, items: FeatureItem[]) =>
   `select Project_ID from ${TABLES[g]} where TypeDescription in(${items.map(({ type }) => type).join(',')})`;
 const intersectProjectIdSubqueries = (g: GeometryKey, items: FeatureItem[]) =>
-  items.map(({ type }) => `select Project_ID from ${TABLES[g]} where TypeDescription=${type}`).join(' intersect ');
+  items
+    .map(({ type }) => `Project_ID in(select Project_ID from ${TABLES[g]} where TypeDescription=${type})`)
+    .join(' and ');
 
 const allTypesSelectedForAllGeometries = (predicates: NormalizedFeaturePredicates) =>
   (['point', 'line', 'poly'] as GeometryKey[]).every((k) => predicates[k] === allRecords);
@@ -224,7 +226,7 @@ const generateExpressions = (
     result.line = addPossibleConjunction(result.line);
     result.poly = addPossibleConjunction(result.poly);
 
-    const expression = `Project_ID in(${expressions.join(` intersect `)})`;
+    const expression = expressions.join(` and `);
     result.centroids += expression;
 
     if (result.point && result.point != noRecords) {


### PR DESCRIPTION
This PR replaces `union` with `or` logic for "any" queries and `intersect` with `and` logic for "all" queries when using the feature type filter.

For example:

```sql
-- Before:
Project_ID in(select Project_ID from POINT where ... union select Project_ID from LINE where ...)

-- After
(Project_ID in(select Project_ID from POINT where ...) OR Project_ID in(select Project_ID from LINE where ...))
```

```sql
-- Before:
Project_ID in(select Project_ID from POINT where TypeDescription='Fish passage structure' intersect select Project_ID from LINE where TypeDescription='Dam')

-- After:
Project_ID in(select Project_ID from POINT where TypeDescription='Fish passage structure') and Project_ID in(select Project_ID from LINE where TypeDescription='Dam')
```

Copilot suggested that these queries may perform slightly better than the union/intersect versions. I didn't notice a difference; they are both pretty quick.